### PR TITLE
Fix: Replace Old Link

### DIFF
--- a/src/modules/org-conformance-pack/README.md
+++ b/src/modules/org-conformance-pack/README.md
@@ -13,7 +13,7 @@ The Conformance Pack cannot be deployed until AWS Config is deployed, which can 
 
 First, make sure your root `account` allows the service access principal `config-multiaccountsetup.amazonaws.com` to
 update child organizations. You can see the docs on the account module here:
-[aws_service_access_principals](https://docs.cloudposse.com/components/library/aws/account/#input_aws_service_access_principals)
+[aws_service_access_principals](https://docs.cloudposse.com/components/library/aws/account/#aws_service_access_principals)
 
 Then you have two options:
 


### PR DESCRIPTION
## what
- Corrected old link reference

## why
- This link is no longer correct and is breaking the workflow for cloudposse/docs

## references
- https://github.com/cloudposse/docs/actions/runs/13117251991/job/36594460731


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated a hyperlink in the documentation to ensure users are directed to the correct reference for AWS service access information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->