### PR TITLE
Allow users to set component names in remote state

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "account-map"
+  component   = var.account_map_component_name
   tenant      = (var.account_map_tenant != "") ? var.account_map_tenant : module.this.tenant
   stage       = var.root_account_stage
   environment = var.global_environment
@@ -15,7 +15,7 @@ module "config_bucket" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "config-bucket"
+  component   = var.config_bucket_component_name
   tenant      = (var.config_bucket_tenant != "") ? var.config_bucket_tenant : module.this.tenant
   stage       = var.config_bucket_stage
   environment = var.config_bucket_env
@@ -30,7 +30,7 @@ module "global_collector_region" {
 
   count = !local.enabled || local.is_global_collector_region ? 0 : 1
 
-  component   = "aws-config-${lookup(module.utils.region_az_alt_code_maps["to_${var.az_abbreviation_type}"], var.global_resource_collector_region)}"
+  component   = "${var.config_component_name}-${lookup(module.utils.region_az_alt_code_maps["to_${var.az_abbreviation_type}"], var.global_resource_collector_region)}"
   stage       = module.this.stage
   environment = lookup(module.utils.region_az_alt_code_maps["to_${var.az_abbreviation_type}"], var.global_resource_collector_region)
   privileged  = false
@@ -42,7 +42,7 @@ module "aws_team_roles" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "aws-team-roles"
+  component   = var.team_roles_component_name
   environment = var.iam_roles_environment_name
 
   context = module.this.context

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -171,3 +171,27 @@ variable "default_scope" {
     error_message = "The scope must be either `account` or `organization`."
   }
 }
+
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of the account-map component"
+  default     = "account-map"
+}
+
+variable "config_component_name" {
+  type        = string
+  description = "The name of the aws config component (i.e., this component)"
+  default     = "aws-config"
+}
+
+variable "config_bucket_component_name" {
+  type        = string
+  description = "The name of the config-bucket component"
+  default     = "config-bucket"
+}
+
+variable "team_roles_component_name" {
+  type        = string
+  description = "The name of the team-roles component"
+  default     = "aws-team-roles"
+}


### PR DESCRIPTION
Allow users to set component names in remote state.

* Defined the input variables `account_map_component_name`, `team_roles_component_name`, and `config_bucket_component_name`.
* The variable `config_component_name` is also defined because it determines how regional instances of this component are referenced, see `src/remote-state.tf` for more.
* Variables default to preserving the behavior of the current version.
* Remote state uses these variables to pull in the state of the components.
* This update allows the codebase to adopt more standardized structure and naming practices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced configuration options to customize component names for account mapping, configuration service, configuration bucket, and team roles.
  - Enabled region-aware naming for the global collector by deriving names from a configurable base plus region suffix.
  - Maintains backward compatibility via sensible defaults; no changes required for existing users.
  - Improves flexibility for multi-environment and multi-region deployments by removing hard-coded names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->