### PR TITLE
Add global_collector_component_name_pattern variable for flexible naming of global AWS Config collector

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -30,7 +30,7 @@ module "global_collector_region" {
 
   count = !local.enabled || local.is_global_collector_region ? 0 : 1
 
-  component   = "${var.config_component_name}-${lookup(module.utils.region_az_alt_code_maps["to_${var.az_abbreviation_type}"], var.global_resource_collector_region)}"
+  component   = format(var.global_collector_component_name_pattern, var.config_component_name, lookup(module.utils.region_az_alt_code_maps["to_${var.az_abbreviation_type}"], var.global_resource_collector_region))
   stage       = module.this.stage
   environment = lookup(module.utils.region_az_alt_code_maps["to_${var.az_abbreviation_type}"], var.global_resource_collector_region)
   privileged  = false

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "account-map"
+  component   = var.account_map_component_name
   tenant      = (var.account_map_tenant != "") ? var.account_map_tenant : module.this.tenant
   stage       = var.root_account_stage
   environment = var.global_environment
@@ -15,7 +15,7 @@ module "config_bucket" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "config-bucket"
+  component   = var.config_bucket_component_name
   tenant      = (var.config_bucket_tenant != "") ? var.config_bucket_tenant : module.this.tenant
   stage       = var.config_bucket_stage
   environment = var.config_bucket_env
@@ -30,7 +30,7 @@ module "global_collector_region" {
 
   count = !local.enabled || local.is_global_collector_region ? 0 : 1
 
-  component   = "aws-config-${lookup(module.utils.region_az_alt_code_maps["to_${var.az_abbreviation_type}"], var.global_resource_collector_region)}"
+  component   = "${var.config_component_name}-${lookup(module.utils.region_az_alt_code_maps["to_${var.az_abbreviation_type}"], var.global_resource_collector_region)}"
   stage       = module.this.stage
   environment = lookup(module.utils.region_az_alt_code_maps["to_${var.az_abbreviation_type}"], var.global_resource_collector_region)
   privileged  = false
@@ -42,7 +42,7 @@ module "aws_team_roles" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "aws-team-roles"
+  component   = var.team_roles_component_name
   environment = var.iam_roles_environment_name
 
   context = module.this.context

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -171,3 +171,27 @@ variable "default_scope" {
     error_message = "The scope must be either `account` or `organization`."
   }
 }
+
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of the account-map component"
+  default     = "account-map"
+}
+
+variable "config_component_name" {
+  type        = string
+  description = "The name of the aws config component (i.e., this component)"
+  default     = "aws-config"
+}
+
+variable "config_bucket_component_name" {
+  type        = string
+  description = "The name of the config-bucket component"
+  default     = "config-bucket"
+}
+
+variable "team_roles_component_name" {
+  type        = string
+  description = "The name of the team-roles component"
+  default     = "aws-team-roles"
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -195,3 +195,19 @@ variable "team_roles_component_name" {
   description = "The name of the team-roles component"
   default     = "aws-team-roles"
 }
+
+variable "global_collector_component_name_pattern" {
+  type        = string
+  description = <<-EOT
+    A string formatting pattern used to construct or look up the name of the
+    global AWS Config collector region component.
+
+    This pattern should align with the regional naming convention of the
+    aws-config component. For example, if the pattern is "%s-%s" and you pass
+    ("aws-config", "use1"), the resulting component name will be "aws-config-use1".
+
+    Adjust this pattern if your environment uses a different naming convention
+    for regional AWS Config components.
+  EOT
+  default     = "%s-%s"
+}


### PR DESCRIPTION
This PR introduces a new variable, `global_collector_component_name_pattern`, which allows customizing the naming convention used when constructing or looking up the global AWS Config collector region component.

* The default pattern is `"%s-%s"`, which produces names like `aws-config-use1`, aligned with the current documentation.
* Provides flexibility for environments that follow different regional naming conventions, i.e., `aws-config/use1`.

This enhancement improves compatibility for organizations with non-standard naming patterns while preserving the existing default behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable pattern for constructing the global AWS Config collector region component name, enabling alignment with custom regional naming conventions.
  * Updated component name construction to use the new pattern, maintaining the previous behavior by default.

* **Chores**
  * Introduced a new input setting with a safe default to support flexible naming without impacting existing deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->