### PR TITLE
Support for AWS Config Resource Type Exclusions

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -83,12 +83,13 @@ module "aws_config" {
   source  = "cloudposse/config/aws"
   version = "1.5.3"
 
-  s3_bucket_id     = local.s3_bucket.config_bucket_id
-  s3_bucket_arn    = local.s3_bucket.config_bucket_arn
-  create_iam_role  = local.create_iam_role
-  iam_role_arn     = local.config_iam_role_arn
-  managed_rules    = var.managed_rules
-  create_sns_topic = true
+  s3_bucket_id                = local.s3_bucket.config_bucket_id
+  s3_bucket_arn               = local.s3_bucket.config_bucket_arn
+  create_iam_role             = local.create_iam_role
+  iam_role_arn                = local.config_iam_role_arn
+  managed_rules               = var.managed_rules
+  exclusion_by_resource_types = var.exclusion_by_resource_types
+  create_sns_topic            = true
 
   global_resource_collector_region   = var.global_resource_collector_region
   central_resource_collector_account = local.central_resource_collector_account

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -133,7 +133,7 @@ variable "exclusion_by_resource_types" {
       "AWS::CloudWatch::Alarm"
     ]
   DOC
-  default     = null
+  default     = []
 }
 
 variable "delegated_accounts" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -118,6 +118,24 @@ variable "conformance_packs" {
   }
 }
 
+variable "exclusion_by_resource_types" {
+  type        = list(string)
+  description = <<-DOC
+    A list of resource types to exclude from recording.
+    Supported resource types are listed here https://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html.
+    Implies recording strategy of `EXCLUSION_BY_RESOURCE_TYPES` and `all_supported` = `false`.
+    Conflicts with `resource_types` (no implemented yet).
+
+    Example:
+
+    exclusion_by_resource_types = [
+      "AWS::Config::ResourceCompliance",
+      "AWS::CloudWatch::Alarm"
+    ]
+  DOC
+  default     = null
+}
+
 variable "delegated_accounts" {
   description = "The account IDs of other accounts that will send their AWS Configuration or Security Hub data to this account"
   type        = set(string)


### PR DESCRIPTION
### Feature: Support for AWS Config Resource Type Exclusions

Added support for excluding specific AWS resource types from AWS Config recording.  
Users can now specify a list of resource types to exclude using the new variable  
`exclusion_by_resource_types`. 

This is based on the capability provided by [PR 133](https://github.com/cloudposse/terraform-aws-config/pull/133) in the `cloudposse/config/aws` module.

#### Example

```terraform
exclusion_by_resource_types = [
  "AWS::Config::ResourceCompliance",
  "AWS::CloudWatch::Alarm"

```

### Changes
- Added variable `exclusion_by_resource_types`.
- Default value: `null` - preserves previous behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a configuration option to exclude specific resource types from AWS Config, enabling more granular control over compliance coverage.

- Improvements
  - The delegated accounts setting is now optional, simplifying configuration for environments that don’t require delegation while preserving existing behavior when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->