### PR TITLE
Remove markdownlint comments from terraform-docs section

### DIFF
--- a/src/modules/org-conformance-pack/README.md
+++ b/src/modules/org-conformance-pack/README.md
@@ -60,7 +60,6 @@ components:
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -119,6 +118,4 @@ components:
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN for the AWS Config Organization Conformance Pack |
-<!-- markdownlint-restore -->
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-


### PR DESCRIPTION
## What

Remove `<!-- markdownlint-disable -->` and `<!-- markdownlint-restore -->` comments from inside the `PRE-COMMIT-TERRAFORM DOCS HOOK` markers in the org-conformance-pack submodule README.

## Why

The `pre-commit-terraform` hook strips everything between the hook markers and replaces it with raw `terraform-docs` output. Since `terraform-docs` doesn't generate the markdownlint comments, every run of `make rebuild-docs` removes them, causing the `check-docs-up-to-date` CI check to fail for downstream consumers that vendor this component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cleaned up module documentation by removing linting directives to improve formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->