### PR TITLE
feat: Add global_collector_component_name variable for explicit remote state lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ components:
         config_bucket_env: ue1
         config_bucket_stage: audit
         sns_encryption_key_id: "alias/aws/sns"
+        global_collector_component_name: "aws-config"
         conformance_packs: []
 ```
 

--- a/README.yaml
+++ b/README.yaml
@@ -227,6 +227,7 @@ usage: |-
           config_bucket_env: ue1
           config_bucket_stage: audit
           sns_encryption_key_id: "alias/aws/sns"
+          global_collector_component_name: "aws-config"
           conformance_packs: []
   ```
 

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -33,7 +33,7 @@ module "global_collector_region" {
 
   count = !local.enabled || local.is_global_collector_region ? 0 : 1
 
-  component   = format(var.global_collector_component_name_pattern, var.config_component_name, lookup(module.utils.region_az_alt_code_maps["to_${var.az_abbreviation_type}"], var.global_resource_collector_region))
+  component   = coalesce(var.global_collector_component_name, format(var.global_collector_component_name_pattern, var.config_component_name, lookup(module.utils.region_az_alt_code_maps["to_${var.az_abbreviation_type}"], var.global_resource_collector_region)))
   stage       = module.this.stage
   environment = lookup(module.utils.region_az_alt_code_maps["to_${var.az_abbreviation_type}"], var.global_resource_collector_region)
   privileged  = false

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -238,8 +238,26 @@ variable "global_collector_component_name_pattern" {
 
     Adjust this pattern if your environment uses a different naming convention
     for regional AWS Config components.
+
+    NOTE: This is only used when `global_collector_component_name` is not set.
   EOT
   default     = "%s-%s"
+}
+
+variable "global_collector_component_name" {
+  type        = string
+  description = <<-EOT
+    Explicit component name for the global collector region remote state lookup.
+    When set, this takes precedence over the pattern-based name construction.
+
+    Use this when your aws-config component uses the same name across all regions
+    (e.g., "aws-config" everywhere), which is the recommended approach. The region
+    differentiation is handled by the stack's environment, not the component name.
+
+    Example: If your stacks are named "core-euw1-security", "core-use1-security",
+    and the component is always "aws-config", set this to "aws-config".
+  EOT
+  default     = null
 }
 
 variable "sns_encryption_key_id" {


### PR DESCRIPTION
## What

Add a new variable `global_collector_component_name` that allows users to explicitly specify the component name for the global collector region remote state lookup. When set, this takes precedence over the pattern-based name construction.

## Why

This addresses an issue where users deploy the same component name (e.g., `aws-config`) across all regions, with region differentiation handled by the stack's environment rather than the component name. The previous pattern-based approach (`global_collector_component_name_pattern`) assumed regional suffixes in component names (e.g., `aws-config-use1`), which does not match current component installation procedures.

## Changes

- Add `global_collector_component_name` variable (default: `null`)
- Update `remote-state.tf` to use `coalesce()` for backwards compatibility
- Update README.yaml and README.md examples to include the new variable

## Backwards Compatibility

This is a backwards-compatible change - existing deployments using the pattern-based naming continue to work unchanged. The new variable only takes effect when explicitly set.

## Usage

```yaml
vars:
  global_collector_component_name: "aws-config"
```

## Environment

- OpenTofu: 1.9.1
- Atmos: 1.197.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Testing

Tested by deploying the component from scratch to multi-account, multi-region AWS deployment (incl. `core-root` and `core-security` account with central finding aggregation in `core-audit`).

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to explicitly set the global collector component name, which overrides the previous pattern-based name when provided.

* **Documentation**
  * Clarified docs and default examples to note that the pattern is only used when an explicit component name is not supplied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->