### PR TITLE
feat: Pass recording_mode variable through to upstream module

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -96,6 +96,7 @@ module "aws_config" {
   global_resource_collector_region   = var.global_resource_collector_region
   central_resource_collector_account = local.central_resource_collector_account
   child_resource_collector_accounts  = local.delegated_accounts
+  recording_mode                     = var.recording_mode
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -242,6 +242,43 @@ variable "global_collector_component_name_pattern" {
   default     = "%s-%s"
 }
 
+variable "recording_mode" {
+  description = <<-DOC
+    The mode for AWS Config to record configuration changes.
+
+    recording_frequency:
+      The default frequency with which AWS Config records configuration changes (CONTINUOUS or DAILY).
+    recording_mode_override:
+      Override the recording frequency for specific resource types.
+
+    Use DAILY recording for high-churn or ephemeral resource types to reduce costs.
+    Resources created and destroyed within a 24-hour period generate zero CIs under DAILY.
+
+    See: https://docs.aws.amazon.com/config/latest/developerguide/select-resources-recording-frequency.html
+
+    Example:
+    ```
+    recording_mode = {
+      recording_frequency = "CONTINUOUS"
+      recording_mode_override = {
+        description         = "Record high-churn resource types daily instead of continuously"
+        recording_frequency = "DAILY"
+        resource_types      = ["AWS::EC2::Instance", "AWS::EC2::EC2Fleet", "AWS::EC2::LaunchTemplate"]
+      }
+    }
+    ```
+  DOC
+  type = object({
+    recording_frequency = string
+    recording_mode_override = optional(object({
+      description         = string
+      recording_frequency = string
+      resource_types      = list(string)
+    }))
+  })
+  default = null
+}
+
 variable "sns_encryption_key_id" {
   type        = string
   description = <<-DOC


### PR DESCRIPTION
## What

Pass the `recording_mode` variable from the component through to the underlying `cloudposse/config/aws` module (v1.5.3), which already supports it but the component does not expose it.

## Why

AWS Config recording costs can be significant in environments with high-churn or ephemeral resources. The `recording_mode` variable allows configuring `recording_mode_override` to switch specific resource types from `CONTINUOUS` to `DAILY` recording.

Under DAILY recording, resources created and destroyed within a 24-hour period generate **zero** Configuration Items — this is particularly impactful for:
- **Karpenter-managed nodes**: EC2 Instances, EC2 Fleets, Launch Templates, and Network Interfaces that are constantly created and destroyed
- **Automated backups**: RDS DB Cluster Snapshots and AWS Backup Recovery Points
- **Self-referential Config resources**: `AWS::Config::ResourceCompliance` re-evaluated many times per day

Reference: [Best practices for analyzing AWS Config recording frequencies](https://aws.amazon.com/blogs/mt/best-practices-for-analyzing-aws-config-recording-frequencies/)

## Changes

- `src/variables.tf`: Add `recording_mode` variable with the same type signature as the upstream module
- `src/main.tf`: Pass `recording_mode` to `module "aws_config"`

## Testing

This change has been tested by deploying to a complete multi-account AWS Organization (10 accounts × 4 regions), including:
- Member account recorders in all regions (eu-west-1, us-east-1, ap-southeast-2, ca-central-1)
- Organization management account recorders
- Centralized aggregation in a dedicated security account
- CIS v1.4 Level 2 and HIPAA conformance packs

All recorders successfully updated with `recording_mode_override` for DAILY frequency on selected resource types.